### PR TITLE
Increase rate step limit

### DIFF
--- a/track/mounts.py
+++ b/track/mounts.py
@@ -193,7 +193,7 @@ class LosmandyGeminiMount(TelescopeMount):
             bypass_ra_limits=False,
             max_slew_rate=4.0,
             max_slew_accel=10.0,
-            max_slew_step=0.4,
+            max_slew_step=1.0,
         ):
         """Inits LosmandyGeminiMount object.
 


### PR DESCRIPTION
I increased the default slew rate step size for the Losmandy mount from 0.4 to 1.0 degrees per second per command. This was motivated by my discovery that in `optical_track` with gamepad override, the acceleration of the mount was more sluggish than when using the `gamepad` program. The root cause was found to be that the rate step limit is too low in cases where the loop iteration is a bit longer, as is the case when the webcam is involved since the frame rate is rather slow. I determined that allowing for slew rate changes of up to 1.0 largely eliminated the issue.

There acceleration of the mount is still less smooth when using `optical_track` due to the slower rate of mount commanding, but this is a much harder problem to solve with the existing camera because it would require sending commands to the mount in a separate thread so they can be asynchronous with the camera. That would create all kinds of other problems. It would actually be easier to just upgrade to a camera with a higher framerate. Fortunately the smoothness with the current camera is not that terrible.