### PR TITLE
Removes dependency_links from setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,16 +9,16 @@ One or more Python packages on which this project depends compile C or C++ code.
 
 Computer vision support is provided by OpenCV. You will need the OpenCV (3.0 or newer) packages and the Python bindings. On Ubuntu this can be accomplished by installing the python3-opencv package using apt which will take care of installing all of the dependencies including the OpenCV packages themselves. These packages are available in the following PPA: ppa:timsc/opencv-3.4.
 
-Camera support requires libv4l to be installed on your system. On Debian-based Linux distributions this is the libv4l package.
+Webcam support requires libv4l to be installed on your system. On Debian-based Linux distributions this is the libv4l package.
 
-Camera support also requires the python-v4l2 package. A patched version is needed since the official version contains a number of bugs and its maintainers are unresponsive. A branch containing the patched version is located here: https://github.com/bgottula/python-v4l2 (but there is no need to clone this). To ensure that the patched version of the v4l2 package mentioned above is installed, pass the `--process-dependency-links` option to pip when installing. You will see an angry warning from pip indicating that this feature is deprecated. We know. Use it anyway.
+Webcam support also requires the python-v4l2 package. A patched version is needed since the official version contains a number of bugs and its maintainers are unresponsive. A branch containing the patched version is located here: https://github.com/bgottula/python-v4l2 (but there is no need to clone this).
 
 ### Optional Dependencies
 Telemetry logging requires InfluxDB to be installed. I recommend downloading the influxdb .deb package from the website to get a relatively recent version (like 1.5.2 or newer). Successful installation of the package will automatically start the influxdb service. Before telemetry logging is possible you will need to manually create a new database named "telem" using the influx client.
 
 ## Install Command
 For the default set of features, install the track package using the following command:
-`sudo pip3 install --process-dependency-links .`
+`sudo pip3 install .`
 
-If you want to install with telemetry support, do:
-`sudo pip3 install --process-dependency-links .[telemetry]`
+If you want to install with telemetry and laser pointer support enabled, do:
+`sudo pip3 install .[telemetry,laser]`

--- a/setup.py
+++ b/setup.py
@@ -42,12 +42,12 @@ setup(
 
     install_requires=[
         'bs4>=0.0.1',
-        'point @ https://github.com/bgottula/point/tarball/master#egg=point-0.3',
+        'point @ https://github.com/seeing-things/point/tarball/master#egg=point-0.3',
         'ConfigArgParse==0.12.0',
         'ephem>=3.7',
         'inputs>=0.1',
         'numpy',
-        'v4l2 @ https://github.com/bgottula/python-v4l2/tarball/master#egg=v4l2-0.2.2',
+        'v4l2 @ https://github.com/seeing-things/python-v4l2/tarball/master#egg=v4l2-0.2.2',
         'requests',
         'MonthDelta>=1.0b',
     ],

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     description='A mess of code for tracking moving objects with a telescope',
     long_description=long_description,
 
-    url='https://github.com/bgottula/track',
+    url='https://github.com/seeing-things/track',
 
     author='Brett Gottula',
     author_email='bgottula@gmail.com',
@@ -42,12 +42,12 @@ setup(
 
     install_requires=[
         'bs4>=0.0.1',
-        'point>=0.3',
+        'point @ https://github.com/bgottula/point/tarball/master#egg=point-0.3',
         'ConfigArgParse==0.12.0',
         'ephem>=3.7',
         'inputs>=0.1',
         'numpy',
-        'v4l2==0.2.2',
+        'v4l2 @ https://github.com/bgottula/python-v4l2/tarball/master#egg=v4l2-0.2.2',
         'requests',
         'MonthDelta>=1.0b',
     ],
@@ -60,11 +60,6 @@ setup(
             'pyftdi>=0.29',
         ],
     },
-
-    dependency_links=[
-        'https://github.com/bgottula/python-v4l2/tarball/master#egg=v4l2-0.2.2',
-        'https://github.com/bgottula/point/tarball/master#egg=point-0.1',
-    ],
 
     entry_points={
         'console_scripts':[


### PR DESCRIPTION
Python devs finally adopted and implemented an approach to replace `process-dependency-links` to allow packages to specify dependencies on other packages that are not in PyPi. This PR fixes setup.py to use the new format for specifying this as described in [PEP508](https://www.python.org/dev/peps/pep-0508/). This was tested on nix with pip 19.2.3 and worked as expected.