### PR TITLE
Stop telem thread and gamepad even if exception raised

### DIFF
--- a/track/align.py
+++ b/track/align.py
@@ -408,14 +408,14 @@ def main():
         print('Unhandled exception: ' + str(e))
     finally:
         # don't rely on destructors to safe mount!
-        print('Safing mount...')
+        print('Safing mount...', end='', flush=True)
         if mount.safe():
             print('Mount safed successfully!')
         else:
             print('Warning: Mount may be in an unsafe state!')
 
-    if args.telem_enable:
-        telem_logger.stop()
+        if args.telem_enable:
+            telem_logger.stop()
 
 if __name__ == "__main__":
     main()

--- a/track/blind_track.py
+++ b/track/blind_track.py
@@ -238,19 +238,19 @@ def main():
     #     print('Unhandled exception: ' + str(e))
     finally:
         # don't rely on destructors to safe mount!
-        print('Safing mount...')
+        print('Safing mount...', end='', flush=True)
         if mount.safe():
             print('Mount safed successfully!')
         else:
             print('Warning: Mount may be in an unsafe state!')
 
-    if args.telem_enable:
-        telem_logger.stop()
+        if args.telem_enable:
+            telem_logger.stop()
 
-    try:
-        game_pad.stop()
-    except:
-        pass
+        try:
+            game_pad.stop()
+        except:
+            pass
 
 if __name__ == "__main__":
     main()

--- a/track/gamepad_control.py
+++ b/track/gamepad_control.py
@@ -102,14 +102,15 @@ def main():
     finally:
         if mount is not None:
             # don't rely on destructors to safe mount!
-            print('Safing mount...')
+            print('Safing mount...', end='', flush=True)
             if mount.safe():
                 print('Mount safed successfully!')
             else:
                 print('Warning: Mount may be in an unsafe state!')
 
-    if args.telem_enable:
-        telem_logger.stop()
+        if args.telem_enable:
+            telem_logger.stop()
+
         game_pad.stop()
 
 if __name__ == "__main__":

--- a/track/hybrid_track.py
+++ b/track/hybrid_track.py
@@ -267,19 +267,19 @@ def main():
         print('Unhandled exception: ' + str(e))
     finally:
         # don't rely on destructors to safe mount!
-        print('Safing mount...')
+        print('Safing mount...', end='', flush=True)
         if mount.safe():
             print('Mount safed successfully!')
         else:
             print('Warning: Mount may be in an unsafe state!')
 
-    if args.telem_enable:
-        telem_logger.stop()
+        if args.telem_enable:
+            telem_logger.stop()
 
-    try:
-        game_pad.stop()
-    except:
-        pass
+        try:
+            game_pad.stop()
+        except:
+            pass
 
 if __name__ == "__main__":
     main()

--- a/track/optical_track.py
+++ b/track/optical_track.py
@@ -167,19 +167,19 @@ def main():
         print('Unhandled exception: ' + str(e))
     finally:
         # don't rely on destructors to safe mount!
-        print('Safing mount...')
+        print('Safing mount...', end='', flush=True)
         if mount.safe():
             print('Mount safed successfully!')
         else:
             print('Warning: Mount may be in an unsafe state!')
 
-    if args.telem_enable:
-        telem_logger.stop()
+        if args.telem_enable:
+            telem_logger.stop()
 
-    try:
-        game_pad.stop()
-    except:
-        pass
+        try:
+            game_pad.stop()
+        except:
+            pass
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
When an exception is raised in a program or when `sys.exit()` is called to abort the program (which raises the `SystemExit` exception), the telemetry and gamepad threads were not being shut down properly, causing the program to stall indefinitely waiting for these threads to end. This PR moves the shutdown code into the `finally` block such that thread shutdown always occurs.