### PR TITLE
Adjust least_squares stopping conditions to speed up solver

### DIFF
--- a/track/model.py
+++ b/track/model.py
@@ -482,6 +482,7 @@ def solve_model(observations: pd.DataFrame) -> Tuple[ModelParameters, OptimizeRe
             max_values.to_ndarray(),
         ),
         args=(observations,),
+        ftol=1e-2,  # compromise between minimizing cost and execution time
     )
 
     if not result.success:


### PR DESCRIPTION
This cuts solver time roughly in half for test cases with negligible increase in RMS error. See https://github.com/seeing-things/track/issues/156#issuecomment-581110644 for details.