### PR TITLE
Real-time priority

### DIFF
--- a/track/blind_track.py
+++ b/track/blind_track.py
@@ -17,6 +17,7 @@ These adjustments are relative to the motion vector of the object across the sky
 """
 
 from configargparse import Namespace
+import os
 import sys
 import ephem
 import numpy as np
@@ -137,6 +138,10 @@ def main():
 
     args = parser.parse_args()
 
+    # Set priority of this thread to realtime. Do this before constructing objects since priority
+    # is inherited and some critical threads are created by libraries we have no direct control
+    # over.
+    os.sched_setscheduler(0, os.SCHED_RR, os.sched_param(11))
 
     # Create object with base type TelescopeMount
     if args.mount_type == 'nexstar':

--- a/track/gamepad.py
+++ b/track/gamepad.py
@@ -4,7 +4,7 @@ Defines a single class Gamepad that provide support for game controller interfac
 program the integrated x- and y- values are printed to the console.
 """
 
-from __future__ import print_function
+import os
 import threading
 import time
 import selectors
@@ -139,6 +139,10 @@ class Gamepad(TelemSource):
         to see if any events are ready. Therefore we must execute this loop
         in its own thread so it doesn't block other processing.
         """
+
+        # Make sure this thread does not have realtime priority
+        os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
+
         while True:
             if not self.running:
                 return
@@ -183,6 +187,10 @@ class Gamepad(TelemSource):
         integrators can continue running even when the input thread is blocked
         waiting for new events from the controller.
         """
+
+        # Make sure this thread does not have realtime priority
+        os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
+
         while True:
             if not self.running:
                 return

--- a/track/hybrid_track.py
+++ b/track/hybrid_track.py
@@ -9,6 +9,7 @@ tracking mode are handled automatically.
 """
 
 from configargparse import Namespace
+import os
 import sys
 import ephem
 import numpy as np
@@ -161,6 +162,11 @@ def main():
 
     cameras.add_program_arguments(parser)
     args = parser.parse_args()
+
+    # Set priority of this thread to realtime. Do this before constructing objects since priority
+    # is inherited and some critical threads are created by libraries we have no direct control
+    # over.
+    os.sched_setscheduler(0, os.SCHED_RR, os.sched_param(11))
 
     # Create object with base type TelescopeMount
     if args.mount_type == 'nexstar':

--- a/track/optical_track.py
+++ b/track/optical_track.py
@@ -11,6 +11,7 @@ An optional gamepad can be used to manually control the mount when no targets ar
 a target is acquired by the camera gamepad control is inhibited.
 """
 
+import os
 import sys
 import track
 from track import cameras
@@ -64,6 +65,10 @@ def main():
     cameras.add_program_arguments(parser)
     args = parser.parse_args()
 
+    # Set priority of this thread to realtime. Do this before constructing objects since priority
+    # is inherited and some critical threads are created by libraries we have no direct control
+    # over.
+    os.sched_setscheduler(0, os.SCHED_RR, os.sched_param(11))
 
     def gamepad_callback(tracker: track.Tracker) -> bool:
         """Callback for gamepad control.

--- a/track/telem.py
+++ b/track/telem.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import os
 import time
 import threading
 import influxdb
@@ -104,6 +105,10 @@ class TelemLogger:
 
     def _worker_thread(self) -> None:
         """Gathers telemetry and posts to database once per sample period."""
+
+        # Make sure this thread does not have realtime priority
+        os.sched_setscheduler(0, os.SCHED_OTHER, os.sched_param(0))
+
         while True:
             if not self.running:
                 return


### PR DESCRIPTION
So track programs don't get starved of CPU when capture is running. I made this program have a higher priority number than capture since I think it would be better to drop a frame here or there than to have erratic behavior from the tracking software. In testing this did not seem to make much difference though; even with the higher priority number track's control loop runs at a slower rate on average when capture is running, but not so bad that I'm overly concerned.

To be clear, the difference between normal and realtime priority was significant and definitely worth making this change.