### PR TITLE
New PID gains, acceleration limits

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'lxml',  # parser for bs4
         'MonthDelta>=1.0b',
         'numpy',
-        'point @ https://github.com/seeing-things/point/tarball/master#egg=point-0.3',
+        'point @ https://github.com/seeing-things/point/tarball/master#egg=point-0.4',
         'requests',
     ],
 

--- a/track/mounts.py
+++ b/track/mounts.py
@@ -366,8 +366,8 @@ class LosmandyGeminiMount(TelescopeMount):
             ra_east_limit: float = 110.0,
             bypass_ra_limits: bool = False,
             max_slew_rate: float = 4.0,
-            max_slew_accel: float = 10.0,
-            max_slew_step: float = 1.0,
+            max_slew_accel: float = 40.0,
+            max_slew_step: float = 0.5,
         ):
         """Inits LosmandyGeminiMount object.
 
@@ -394,6 +394,7 @@ class LosmandyGeminiMount(TelescopeMount):
             rate_limit=max_slew_rate,
             rate_step_limit=max_slew_step,
             accel_limit=max_slew_accel,
+            use_multiprocessing=True,
         )
 
         # If Gemini startup is not complete the coordinates it reports will not correspond to its

--- a/track/targets.py
+++ b/track/targets.py
@@ -1,10 +1,14 @@
 """targets for use in telescope tracking control loop"""
 
+from typing import Tuple
+import time
 from abc import ABC, abstractmethod
-from astropy.coordinates import EarthLocation, SkyCoord, AltAz
+from astropy.coordinates import EarthLocation, SkyCoord, AltAz, Longitude
 from astropy.time import Time
 from astropy import units as u
 import ephem
+from track.model import MountModel
+from track.mounts import MountEncoderPositions
 
 
 class Target(ABC):
@@ -39,6 +43,51 @@ class FixedTopocentricTarget(Target):
     def get_position(self, t: Time = None) -> SkyCoord:
         """Since the topocentric position is fixed the t argument is ignored"""
         return self.coord
+
+
+class AcceleratingMountAxisTarget(Target):
+    """A target that accelerates at a constant rate in one or both mount axes.
+
+    This target is intented for testing the control system's ability to track an accelerating
+    target with reasonably small steady-state error.
+    """
+
+    def __init__(
+            self,
+            mount_model: MountModel,
+            initial_encoder_positions: MountEncoderPositions,
+            axis_accelerations: Tuple[float, float],
+        ):
+        """Construct an AcceleratingMountAxisTarget.
+
+        Initial velocity of the target is zero in both axes. Acceleration begins the moment this
+        constructor is called and continues forever without limit as currently implemented.
+
+        Args:
+            mount_model: An instance of the mount model. This is required because the acceleration
+                is meant to be held constant in the mount axes, yet the API of the Target class
+                requires a topocentric coordinate be returned by the `get_position()` method.
+            initial_encoder_positions: The starting positions of the mount encoders. Note that if
+                axis 1 starts out pointed at the pole and has acceleration 0 axis 0 may not behave
+                as expected since the pole is a singularity. A work-round is to set the initial
+                encoder position for axis 1 to a small offset from the pole, or to use a non-zero
+                acceleration for axis 1.
+            axis_accelerations: A tuple of two floats giving the accelerations in axis 0 and axis
+                1, respectively, in degrees per second squared (negative okay).
+        """
+        self.mount_model = mount_model
+        self.accel = axis_accelerations
+        self.time_start = Time.now()
+        self.initial_positions = initial_encoder_positions
+
+    def get_position(self, t: Time):
+        """Gets the position of the simulated target for a specific time."""
+        time_elapsed = (t - self.time_start).sec
+        target_encoder_positions = MountEncoderPositions(
+            Longitude((self.initial_positions[0].deg + self.accel[0] * time_elapsed**2) * u.deg),
+            Longitude((self.initial_positions[1].deg + self.accel[1] * time_elapsed**2) * u.deg),
+        )
+        return self.mount_model.encoders_to_topocentric(target_encoder_positions)
 
 
 class PyEphemTarget(Target):


### PR DESCRIPTION
This finally solves a very long-standing issue where the system is unable to keep up with accelerating targets. The adjustments here allow for tracking a target accelerating at up to 0.2 deg/s/s in either or both mount axes while maintaining a steady state error rate in that axis of less than 0.01 degrees (36 arcseconds), which is roughly 10% of the height of an ASI178 camera frame at prime focus of an EdgeHD 11.

This depends on changes to the point package which allow smoother (and therefore faster, with out stalling) acceleration: https://github.com/seeing-things/point/pull/45