### PR TITLE
Separate camera args for alignment and tracking

### DIFF
--- a/track/align.py
+++ b/track/align.py
@@ -203,7 +203,7 @@ def main():
         default=0.2,
         type=float
     )
-    cameras.add_program_arguments(parser)
+    cameras.add_program_arguments(parser, profile='align')
     args = parser.parse_args()
 
     if args.mount_type == 'gemini':
@@ -275,7 +275,7 @@ def main():
     tracker.stop_when_converged = True
     tracker.converge_max_error_mag = Angle(2.0 * u.deg)
 
-    camera = cameras.make_camera_from_args(args)
+    camera = cameras.make_camera_from_args(args, profile='align')
 
     if args.telem_enable:
         telem_logger = track.TelemLogger(

--- a/track/cameras.py
+++ b/track/cameras.py
@@ -133,19 +133,44 @@ class ASICamera(Camera):
             return 1 if self == self.RAW8 else 2
 
     @staticmethod
-    def add_program_arguments(parser: ArgParser) -> None:
-        parser.add_argument(
-            '--zwo-exposure-time',
-            help='ZWO camera exposure time in seconds',
-            default=0.5,
-            type=float
-        )
-        parser.add_argument(
-            '--zwo-gain',
-            help='ZWO camera gain',
-            default=400,
-            type=int
-        )
+    def add_program_arguments(parser: ArgParser, profile: str) -> None:
+        """Adds program arguments for ZWO ASI camera configuration.
+
+        Args:
+            parser: The instance of ArgParser to which this function will add arguments.
+            profile: 'track' or 'align' to indicate which set of arguments to add.
+
+        Raises:
+            ValueError if profile is set to an invalid string.
+        """
+        if profile == 'align':
+            parser.add_argument(
+                '--zwo-exposure-time-align',
+                help='ZWO camera exposure time used during alignment in seconds',
+                default=0.5,
+                type=float
+            )
+            parser.add_argument(
+                '--zwo-gain-align',
+                help='ZWO camera gain used during alignment',
+                default=400,
+                type=int
+            )
+        elif profile == 'track':
+            parser.add_argument(
+                '--zwo-exposure-time',
+                help='ZWO camera exposure time used during tracking in seconds',
+                default=0.03,
+                type=float
+            )
+            parser.add_argument(
+                '--zwo-gain',
+                help='ZWO camera gain used during tracking',
+                default=10,
+                type=int
+            )
+        else:
+            ValueError('profile must be "track" or "align"')
         parser.add_argument(
             '--zwo-binning',
             help='ZWO camera binning',
@@ -159,15 +184,35 @@ class ASICamera(Camera):
         )
 
     @staticmethod
-    def from_program_args(args: Namespace) -> 'ASICamera':
-        """Factory to make a WebCam instance from program arguments"""
+    def from_program_args(args: Namespace, profile: str) -> 'ASICamera':
+        """Factory to make a WebCam instance from program arguments
+
+        Args:
+            args: Set of program arguments.
+            profile: Set to 'tracking' to use the tracking gain and exposure time or to 'align' to
+                use the alignment gain and exposure time.
+
+        Returns:
+            An instance of ASICamera initialized with the appropriate configuration.
+
+        Raises:
+            ValueError if profile is set to an invalid string.
+        """
         camera = ASICamera(
             pixel_scale=args.camera_pixel_scale / 3600.0,
             binning=args.zwo_binning,
             name=args.zwo_name,
         )
-        camera.exposure = args.zwo_exposure_time
-        camera.gain = args.zwo_gain
+        if profile == 'track':
+            camera.exposure = args.zwo_exposure_time
+            camera.gain = args.zwo_gain
+            camera.video_mode = True
+        elif profile == 'align':
+            camera.exposure = args.zwo_exposure_time_align
+            camera.gain = args.zwo_gain_align
+            camera.video_mode = False
+        else:
+            raise ValueError('profile must be "track" or "align"')
         return camera
 
     def __init__(
@@ -378,7 +423,7 @@ class WebCam(Camera):
     """Webcams or other cameras that can be accessed using the 'Video4Linux' (V4L) drivers."""
 
     @staticmethod
-    def add_program_arguments(parser: ArgParser) -> None:
+    def add_program_arguments(parser: ArgParser, profile: str) -> None:
         parser.add_argument('--webcam-dev', help='webcam device node path', default='/dev/video0')
         parser.add_argument(
             '--webcam-exposure',
@@ -392,7 +437,7 @@ class WebCam(Camera):
         )
 
     @staticmethod
-    def from_program_args(args: Namespace) -> 'WebCam':
+    def from_program_args(args: Namespace, profile: str) -> 'WebCam':
         """Factory to make a WebCam instance from program arguments"""
         return WebCam(
             dev_path=args.webcam_dev,
@@ -746,8 +791,13 @@ class WebCam(Camera):
             f.write(jpeg)
 
 
-def add_program_arguments(parser: ArgParser) -> None:
-    """Add program arguments for all cameras"""
+def add_program_arguments(parser: ArgParser, profile: str) -> None:
+    """Add program arguments for all cameras.
+
+    Args:
+        parser: The instance of ArgParser to which this function will add arguments.
+        profile: 'track' or 'align' to indicate which set of arguments to add.
+    """
     parser.add_argument(
         '--camera-type',
         help='type of camera',
@@ -765,18 +815,23 @@ def add_program_arguments(parser: ArgParser) -> None:
         title='Webcam Options',
         description='Options that apply when camera-type is set to "webcam"',
     )
-    WebCam.add_program_arguments(webcam_group)
+    WebCam.add_program_arguments(webcam_group, profile)
     zwo_group = parser.add_argument_group(
         title='ZWO ASI Camera Options',
         description='Options that apply when camera-type is set to "zwo"',
     )
-    ASICamera.add_program_arguments(zwo_group)
+    ASICamera.add_program_arguments(zwo_group, profile)
 
 
-def make_camera_from_args(args: Namespace) -> Camera:
-    """Construct the appropriate camera based on the program arguments provided."""
+def make_camera_from_args(args: Namespace, profile: str) -> Camera:
+    """Construct the appropriate camera based on the program arguments provided.
+
+    Args:
+        args: Set of program arguments.
+        profile: 'track' or 'align' to indicate which set of arguments to add.
+    """
     if args.camera_type == 'webcam':
-        return WebCam.from_program_args(args)
+        return WebCam.from_program_args(args, profile)
     if args.camera_type == 'zwo':
-        return ASICamera.from_program_args(args)
-    raise ValueError('Invalid camera-type {}'.format(args.camera_type))
+        return ASICamera.from_program_args(args, profile)
+    raise ValueError(f'Invalid camera-type {args.camera_type}')

--- a/track/hybrid_track.py
+++ b/track/hybrid_track.py
@@ -144,7 +144,7 @@ def main():
         'name',
         help='name of planet or moon')
 
-    cameras.add_program_arguments(parser)
+    cameras.add_program_arguments(parser, profile='track')
     args = parser.parse_args()
 
     # Set priority of this thread to realtime. Do this before constructing objects since priority
@@ -183,8 +183,7 @@ def main():
 
     # Create object with base type ErrorSource
     mount_model = track.model.load_default_model()
-    camera = cameras.make_camera_from_args(args)
-    camera.video_mode = True
+    camera = cameras.make_camera_from_args(args, profile='track')
     error_source = HybridErrorSource(
         mount=mount,
         mount_model=mount_model,

--- a/track/optical_track.py
+++ b/track/optical_track.py
@@ -62,7 +62,7 @@ def main():
         '--laser-ftdi-serial',
         help='serial number of laser pointer FTDI device',
     )
-    cameras.add_program_arguments(parser)
+    cameras.add_program_arguments(parser, profile='track')
     args = parser.parse_args()
 
     # Set priority of this thread to realtime. Do this before constructing objects since priority
@@ -110,8 +110,7 @@ def main():
 
     # Create object with base type ErrorSource
     mount_model = track.model.load_default_model()
-    camera = cameras.make_camera_from_args(args)
-    camera.video_mode = True
+    camera = cameras.make_camera_from_args(args, profile='track')
     error_source = track.OpticalErrorSource(
         camera=camera,
         mount=mount,

--- a/track/startracker.py
+++ b/track/startracker.py
@@ -18,10 +18,10 @@ def main():
         help='skip plate solving',
         action='store_true'
     )
-    cameras.add_program_arguments(parser)
+    cameras.add_program_arguments(parser, profile='align')
     args = parser.parse_args()
 
-    camera = cameras.make_camera_from_args(args)
+    camera = cameras.make_camera_from_args(args, profile='align')
 
     cv2.namedWindow('camera', cv2.WINDOW_NORMAL)
     cv2.resizeWindow('camera', 640, 480)


### PR DESCRIPTION
The gain and exposure time settings for the camera are provided by
program arguments which may be stored in a configuration file. The
values for these parameters that are appropriate for alignment, which
need longer single-shot exposures, are not the same values appropriate
for tracking, which requires shorter exposures. This commit creates
separate arguments for both cases so they can be specified separately in
the same config file.