### PR TITLE
Remove manual numpy install in GitHub workflow

### DIFF
--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -27,7 +27,6 @@ jobs:
         sudo apt install libasicamera2
         python -m pip install --upgrade pip
         pip install pylint
-        pip install numpy  # required until https://github.com/seeing-things/zwo/issues/66 is resolved
         pip install .
     - name: Lint with pylint
       run: |
@@ -50,7 +49,6 @@ jobs:
         sudo apt update
         sudo apt install libasicamera2
         python -m pip install --upgrade pip
-        pip install numpy  # required until https://github.com/seeing-things/zwo/issues/66 is resolved
         pip install .
     - name: Run unit tests
       run: |


### PR DESCRIPTION
This was required as a work-around for a bug in the asi Python package
setup.py script.